### PR TITLE
Upgrade android sdk per latest docs

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ version '1.0-SNAPSHOT'
 
 buildscript {
     ext.kotlin_version = '1.4.0'
-    ext.bugsnag_version = '5.5.2'
+    ext.bugsnag_version = '5.+'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
For some reason version `5.5.2` is not found when pulling the dependencies any more.  I set the version per the docs [here](https://docs.bugsnag.com/platforms/android/)

@Moujarkash I've validated it builds but are there any additional test I need to do?

